### PR TITLE
Add split-screen ChatGPT frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,9 @@
 # ChatgptFrontend
+
+This project contains a simple front-end clone of ChatGPT that displays the conversation in a split screen. The right side shows the most recent prompts while the left side keeps the earlier part of the same chat. The interface is implemented with plain HTML, CSS and JavaScript and does not connect to any back‑end service.
+
+## Usage
+
+Open `index.html` in any modern web browser. Type a message into the text box on the right and press **Send** or hit **Enter**. New prompts appear in the right panel. When more than five message pairs accumulate, the oldest ones automatically move to the left panel so you can easily scroll through long text.
+
+No additional dependencies are required.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>ChatGPT Split Screen Clone</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <h1>ChatGPT Split Screen Clone</h1>
+    <div id="container">
+        <div id="old-messages" class="panel">
+            <h2>Old Prompts</h2>
+            <div class="messages" id="old-content"></div>
+        </div>
+        <div id="new-messages" class="panel">
+            <h2>New Prompts</h2>
+            <div class="messages" id="new-content"></div>
+            <div id="input-area">
+                <input type="text" id="user-input" placeholder="Type a message" />
+                <button id="send-btn">Send</button>
+            </div>
+        </div>
+    </div>
+
+    <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,54 @@
+const oldContent = document.getElementById('old-content');
+const newContent = document.getElementById('new-content');
+const userInput = document.getElementById('user-input');
+const sendBtn = document.getElementById('send-btn');
+
+// store message pairs in the new panel
+let newMessages = [];
+
+function addMessage(userText, responseText) {
+    const messageWrapper = document.createElement('div');
+    messageWrapper.classList.add('message');
+
+    const userSpan = document.createElement('span');
+    userSpan.classList.add('user');
+    userSpan.textContent = userText;
+
+    const responseSpan = document.createElement('span');
+    responseSpan.classList.add('response');
+    responseSpan.textContent = responseText;
+
+    messageWrapper.appendChild(userSpan);
+    messageWrapper.appendChild(document.createElement('br'));
+    messageWrapper.appendChild(responseSpan);
+
+    newContent.appendChild(messageWrapper);
+    newMessages.push(messageWrapper);
+
+    // move messages to old panel if more than 5 pairs in new panel
+    if (newMessages.length > 5) {
+        const oldMessage = newMessages.shift();
+        newContent.removeChild(oldMessage);
+        oldContent.appendChild(oldMessage);
+    }
+
+    // scroll to bottom of new panel
+    newContent.scrollTop = newContent.scrollHeight;
+}
+
+function handleSend() {
+    const text = userInput.value.trim();
+    if (!text) return;
+
+    // Placeholder response: echo the prompt
+    const response = `Echo: ${text}`;
+    addMessage(text, response);
+    userInput.value = '';
+}
+
+sendBtn.addEventListener('click', handleSend);
+userInput.addEventListener('keypress', (e) => {
+    if (e.key === 'Enter') {
+        handleSend();
+    }
+});

--- a/style.css
+++ b/style.css
@@ -1,0 +1,60 @@
+body {
+    font-family: Arial, sans-serif;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    height: 100vh;
+}
+
+h1 {
+    text-align: center;
+    margin: 10px 0;
+}
+
+#container {
+    display: flex;
+    flex: 1;
+    overflow: hidden;
+}
+
+.panel {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    border: 1px solid #ccc;
+}
+
+.messages {
+    flex: 1;
+    padding: 10px;
+    overflow-y: auto;
+}
+
+.message {
+    margin-bottom: 10px;
+}
+
+.user {
+    font-weight: bold;
+    color: #007bff;
+}
+
+.response {
+    margin-left: 10px;
+}
+
+#input-area {
+    display: flex;
+    border-top: 1px solid #ccc;
+    padding: 10px;
+}
+
+#user-input {
+    flex: 1;
+    padding: 5px;
+}
+
+#send-btn {
+    padding: 5px 10px;
+}


### PR DESCRIPTION
## Summary
- create HTML/CSS/JS for a basic ChatGPT-style interface
- split screen to show old prompts on the left and new prompts on the right
- automatically move old messages to the left panel when more than 5 pairs accumulate
- update README with instructions

## Testing
- `git status --short`
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_684edcf2c0ec832aa7862cd021d257bd